### PR TITLE
Add support for spendkey import, 'deleteWallet' endpoint

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1460,15 +1460,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1693,7 +1693,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.2"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "bech32",
  "bs58",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.12.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "android_logger",
  "base64",
@@ -2378,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.10.3"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "android_logger",
  "bs58",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "aes",
  "bip0039",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.1.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
 dependencies = [
  "document-features",
  "memuse",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.2"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "bech32",
  "bs58",
@@ -2344,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.12.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "android_logger",
  "base64",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.10.3"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "android_logger",
  "bs58",
@@ -2420,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -2468,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "aes",
  "bip0039",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.1.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#7c8ed39bcc62f71185f68039f9b83404f529f59f"
 dependencies = [
  "document-features",
  "memuse",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base58"
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -266,9 +266,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chacha20"
@@ -366,9 +366,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -474,18 +474,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "blake2b_simd",
 ]
@@ -569,7 +569,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -636,19 +636,26 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+checksum = "019561b5f3be60731e7b72f3f7878c5badb4174362d860b03d3cf64cb47f90db"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
  "halo2_legacy_pdqsort",
+ "indexmap 1.9.3",
  "maybe-rayon",
  "pasta_curves",
  "rand_core",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -662,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "hashlink"
@@ -708,9 +715,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -747,12 +754,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -845,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -911,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memuse"
@@ -1135,7 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -1145,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -1188,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1269,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1535,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
 dependencies = [
  "cc",
 ]
@@ -1622,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -1652,9 +1669,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1702,12 +1719,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1782,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1793,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1915,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2058,6 +2074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,11 +2106,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2101,6 +2142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2158,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2125,10 +2178,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2143,6 +2208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,6 +2224,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2167,6 +2244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2260,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -2235,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.2"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "bech32",
  "bs58",
@@ -2248,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.12.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "android_logger",
  "base64",
@@ -2289,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.10.3"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "android_logger",
  "bs58",
@@ -2324,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2333,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -2372,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "aes",
  "bip0039",
@@ -2407,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2429,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.1.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=verus-revert#7b515874319070f0a114076f10f7bc471d3108cc"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b4cd6f26e4cb499f738ace19c35d70bdd659d89e"
 dependencies = [
  "document-features",
  "memuse",
@@ -2446,18 +2535,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "shlex",
 ]
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "blake2b_simd",
 ]
@@ -844,11 +844,11 @@ dependencies = [
 
 [[package]]
 name = "known-folders"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d9a1740cc8b46e259a0eb787d79d855e79ff10b9855a5eba58868d5da7927c"
+checksum = "c644f4623d1c55eb60a9dac35e0858a59f982fb87db6ce34c872372b0a5b728f"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -897,9 +897,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "log"
@@ -1489,7 +1489,8 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.1.3"
-source = "git+https://github.com/who-biz/sapling-crypto?branch=spendkey-import#48e5fd84c599606cf96dbb28d89a5573effb099e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f4270033afcb0c74c5c7d59c73cfd1040367f67f224fe7ed9a919ae618f1b7"
 dependencies = [
  "aes",
  "bellman",
@@ -2055,6 +2056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,7 +2085,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2114,10 +2121,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2323,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.2"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "bech32",
  "bs58",
@@ -2336,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.12.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "android_logger",
  "base64",
@@ -2377,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.10.3"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "android_logger",
  "bs58",
@@ -2412,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2421,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -2460,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "aes",
  "bip0039",
@@ -2495,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2517,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.1.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#b3786131fac64b05712fd3888008d51ee584823a"
 dependencies = [
  "document-features",
  "memuse",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1489,8 +1489,7 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f4270033afcb0c74c5c7d59c73cfd1040367f67f224fe7ed9a919ae618f1b7"
+source = "git+https://github.com/who-biz/sapling-crypto?branch=spendkey-import#48e5fd84c599606cf96dbb28d89a5573effb099e"
 dependencies = [
  "aes",
  "bellman",
@@ -2324,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.2"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "bech32",
  "bs58",
@@ -2337,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.12.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "android_logger",
  "base64",
@@ -2378,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.10.3"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "android_logger",
  "bs58",
@@ -2413,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2422,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.2.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -2461,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "aes",
  "bip0039",
@@ -2496,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.15.0"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2518,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.1.1"
-source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#a2708eb5b50521c56520b9118e794e5da7c541b0"
+source = "git+https://github.com/who-biz/librustzcash?branch=spendkey-import#81a6656ca95e06ed8ed24a2f41be136ae9dc18de"
 dependencies = [
  "document-features",
  "memuse",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -68,7 +68,7 @@ zcash_client_backend = { git = "https://github.com/who-biz/librustzcash", branch
 zcash_client_sqlite = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
 zcash_primitives = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
 zcash_proofs = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
-sapling-crypto = { git = "https://github.com/who-biz/sapling-crypto", branch = "spendkey-import" }
+#sapling-crypto = { git = "https://github.com/who-biz/sapling-crypto", branch = "spendkey-import" }
 
 [lib]
 name = "zcashwalletsdk"

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -68,6 +68,7 @@ zcash_client_backend = { git = "https://github.com/who-biz/librustzcash", branch
 zcash_client_sqlite = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
 zcash_primitives = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
 zcash_proofs = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
+sapling-crypto = { git = "https://github.com/who-biz/sapling-crypto", branch = "spendkey-import" }
 
 [lib]
 name = "zcashwalletsdk"

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -63,11 +63,11 @@ transparent-inputs = []
 
 ## Uncomment this to test someone else's librustzcash changes in a branch
 [patch.crates-io]
-zcash_address = { git = "https://github.com/who-biz/librustzcash", branch = "verus-revert" }
-zcash_client_backend = { git = "https://github.com/who-biz/librustzcash", branch = "verus-revert" }
-zcash_client_sqlite = { git = "https://github.com/who-biz/librustzcash", branch = "verus-revert" }
-zcash_primitives = { git = "https://github.com/who-biz/librustzcash", branch = "verus-revert" }
-zcash_proofs = { git = "https://github.com/who-biz/librustzcash", branch = "verus-revert" }
+zcash_address = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
+zcash_client_backend = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
+zcash_client_sqlite = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
+zcash_primitives = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
+zcash_proofs = { git = "https://github.com/who-biz/librustzcash", branch = "spendkey-import" }
 
 [lib]
 name = "zcashwalletsdk"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -56,6 +56,9 @@ interface Backend {
     @Throws(RuntimeException::class)
     suspend fun initDataDb(transparentKey: ByteArray?, extsk: ByteArray?, seed: ByteArray?): Int
 
+    /*@Throws(RuntimeException::class)
+    suspend fun deleteDb(clearCache: Boolean, clearDataDb: Boolean): Boolean
+    */
     /**
      * @throws RuntimeException as a common indicator of the operation failure
      */

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -62,6 +62,7 @@ interface Backend {
     @Throws(RuntimeException::class)
     suspend fun createAccount(
         transparentKey: ByteArray?,
+        extsk: String?,
         seed: ByteArray,
         treeState: ByteArray,
         recoverUntil: Long?

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -54,7 +54,7 @@ interface Backend {
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)
-    suspend fun initDataDb(transparentKey: ByteArray?, seed: ByteArray?): Int
+    suspend fun initDataDb(transparentKey: ByteArray?, extsk: ByteArray?, seed: ByteArray?): Int
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
@@ -62,8 +62,8 @@ interface Backend {
     @Throws(RuntimeException::class)
     suspend fun createAccount(
         transparentKey: ByteArray?,
-        extsk: String?,
-        seed: ByteArray,
+        extsk: ByteArray?,
+        seed: ByteArray?,
         treeState: ByteArray,
         recoverUntil: Long?
     ): JniUnifiedSpendingKey
@@ -72,7 +72,7 @@ interface Backend {
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)
-    suspend fun isSeedRelevantToAnyDerivedAccounts(transparentKey: ByteArray, seed: ByteArray): Boolean
+    suspend fun isSeedRelevantToAnyDerivedAccounts(transparentKey: ByteArray, extsk: ByteArray, seed: ByteArray): Boolean
     //TODO: pretty sure we don't need WIF evaluated here, but leaving here for completeness of process
 
     fun isValidSaplingAddr(addr: String): Boolean

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Derivation.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Derivation.kt
@@ -28,6 +28,7 @@ interface Derivation {
 
     fun deriveUnifiedSpendingKey(
         transparentKey: ByteArray,
+        extendedSecretKey: ByteArray,
         seed: ByteArray,
         networkId: Int,
         accountIndex: Int

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -77,6 +77,13 @@ class RustBackend private constructor(
             )
         }
 
+/*    override suspend fun deleteDb(
+       clearCache: Boolean,
+       clearDataDb: Boolean
+    ): Boolean {
+             return this.clear(clearCache, clearDataDb)
+    }
+*/
     override suspend fun createAccount(
         transparentKey: ByteArray?,
         extsk: ByteArray?,
@@ -450,6 +457,12 @@ class RustBackend private constructor(
             networkId: Int
         ): Int
 
+/*        @JvmStatic
+        private external fun deleteDb(
+             clearCache: Boolean,
+             clearDataDb: Boolean
+        ): Boolean
+*/
         @JvmStatic
         private external fun createAccount(
             dbDataPath: String,

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -78,6 +78,7 @@ class RustBackend private constructor(
 
     override suspend fun createAccount(
         transparentKey: ByteArray?,
+        extsk: String?,
         seed: ByteArray,
         treeState: ByteArray,
         recoverUntil: Long?
@@ -86,6 +87,7 @@ class RustBackend private constructor(
             createAccount(
                 dataDbFile.absolutePath,
                 transparentKey,
+                extsk,
                 seed,
                 treeState,
                 recoverUntil ?: -1,
@@ -449,6 +451,7 @@ class RustBackend private constructor(
         private external fun createAccount(
             dbDataPath: String,
             transparentKey: ByteArray?,
+            extsk: String?,
             seed: ByteArray,
             treeState: ByteArray,
             recoverUntil: Long,

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -66,11 +66,12 @@ class RustBackend private constructor(
             )
         }
 
-    override suspend fun initDataDb(transparentKey: ByteArray?, seed: ByteArray?) =
+    override suspend fun initDataDb(transparentKey: ByteArray?, extsk: ByteArray?, seed: ByteArray?) =
         withContext(SdkDispatchers.DATABASE_IO) {
             initDataDb(
                 dataDbFile.absolutePath,
                 transparentKey,
+                extsk,
                 seed,
                 networkId = networkId
             )
@@ -78,8 +79,8 @@ class RustBackend private constructor(
 
     override suspend fun createAccount(
         transparentKey: ByteArray?,
-        extsk: String?,
-        seed: ByteArray,
+        extsk: ByteArray?,
+        seed: ByteArray?,
         treeState: ByteArray,
         recoverUntil: Long?
     ): JniUnifiedSpendingKey {
@@ -96,11 +97,12 @@ class RustBackend private constructor(
         }
     }
 
-    override suspend fun isSeedRelevantToAnyDerivedAccounts(transparentKey: ByteArray, seed: ByteArray): Boolean =
+    override suspend fun isSeedRelevantToAnyDerivedAccounts(transparentKey: ByteArray, extsk: ByteArray, seed: ByteArray): Boolean =
         withContext(SdkDispatchers.DATABASE_IO) {
             isSeedRelevantToAnyDerivedAccounts(
                 dataDbFile.absolutePath,
                 transparentKey,
+                extsk,
                 seed,
                 networkId = networkId
             )
@@ -443,6 +445,7 @@ class RustBackend private constructor(
         private external fun initDataDb(
             dbDataPath: String,
             transparentKey: ByteArray?,
+            extsk: ByteArray?,
             seed: ByteArray?,
             networkId: Int
         ): Int
@@ -451,8 +454,8 @@ class RustBackend private constructor(
         private external fun createAccount(
             dbDataPath: String,
             transparentKey: ByteArray?,
-            extsk: String?,
-            seed: ByteArray,
+            extsk: ByteArray?,
+            seed: ByteArray?,
             treeState: ByteArray,
             recoverUntil: Long,
             networkId: Int
@@ -462,6 +465,7 @@ class RustBackend private constructor(
         private external fun isSeedRelevantToAnyDerivedAccounts(
             dbDataPath: String,
             transparentKey: ByteArray,
+            extsk: ByteArray,
             seed: ByteArray,
             networkId: Int
         ): Boolean

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustDerivationTool.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustDerivationTool.kt
@@ -18,10 +18,11 @@ class RustDerivationTool private constructor() : Derivation {
 
     override fun deriveUnifiedSpendingKey(
         transparentKey: ByteArray,
+        extendedSecretKey: ByteArray,
         seed: ByteArray,
         networkId: Int,
         accountIndex: Int
-    ): JniUnifiedSpendingKey = deriveSpendingKey(transparentKey, seed, accountIndex, networkId = networkId)
+    ): JniUnifiedSpendingKey = deriveSpendingKey(transparentKey, extendedSecretKey, seed, accountIndex, networkId = networkId)
 
     override fun deriveSaplingSpendingKey(
         seed: ByteArray,
@@ -82,6 +83,7 @@ class RustDerivationTool private constructor() : Derivation {
         @JvmStatic
         private external fun deriveSpendingKey(
             transparentKey: ByteArray,
+            extendedSecretKey: ByteArray,
             seed: ByteArray,
             account: Int,
             networkId: Int

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -1806,7 +1806,8 @@ fn zip317_helper<DbT>(
     use_zip317_fees: jboolean,
 ) -> GreedyInputSelector<DbT, SingleOutputChangeStrategy> {
     let fee_rule = if use_zip317_fees == JNI_TRUE {
-        StandardFeeRule::Zip317
+        StandardFeeRule::PreZip313
+   //     StandardFeeRule::Zip317
     } else {
         #[allow(deprecated)]
         StandardFeeRule::PreZip313

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -256,6 +256,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_initDataD
     _: JClass<'local>,
     db_data: JString<'local>,
     transparent_key: JByteArray<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     network_id: jint,
 ) -> jint {
@@ -264,11 +265,21 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_initDataD
         let mut db_data = wallet_db(env, network, db_data)
             .map_err(|e| anyhow!("Error while opening data DB: {}", e))?;
 
+        if (seed.is_null() && extsk.is_null()) {
+            // throw error
+        }
+
+        if (!seed.is_null() && !extsk.is_null()) {
+            // throw error
+        }
+
         let seed = (!seed.is_null()).then(|| SecretVec::new(env.convert_byte_array(seed).unwrap()));
+
+        let extsk = (!extsk.is_null()).then(|| SecretVec::new(env.convert_byte_array(extsk).unwrap()));
 
         let transparent_key = (!transparent_key.is_null()).then(|| SecretVec::new(env.convert_byte_array(transparent_key).unwrap()));
 
-        match init_wallet_db(&mut db_data, transparent_key, seed) {
+        match init_wallet_db(&mut db_data, transparent_key, extsk, seed) {
             Ok(()) => Ok(0),
             Err(e)
                 if matches!(
@@ -362,7 +373,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createAcc
     _: JClass<'local>,
     db_data: JString<'local>,
     transparent_key: JByteArray<'local>,
-    extsk: JString<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     treestate: JByteArray<'local>,
     recover_until: jlong,
@@ -376,15 +387,16 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createAcc
         //let tkey = env.convert_byte_array(transparent_key).unwrap_or(Vec::new());
         //warn!("Jni boundary, transparent_key: {:?}, length: {}", tkey, tkey.len());
         let transparent_key = SecretVec::new(env.convert_byte_array(transparent_key).unwrap_or(Vec::new()));
+        let extsk = SecretVec::new(env.convert_byte_array(extsk).unwrap_or(Vec::new()));
 
 //        let bytes: Vec<u8>;
-        let extsk_rust: String = env.get_string(&extsk)?.into();
-        if !extsk_rust.is_empty() {
-            let result = decode_extended_spending_key(mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY, &extsk_rust);
-            warn!("bech32 decode: result({:?})", result);
-        } else {
-            warn!("extsk JString was empty!!");
-        }
+   //     let extsk_rust: String = env.get_string(&extsk)?.into();
+     //   if !extsk_rust.is_empty() {
+     //       let result = decode_extended_spending_key(mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY, &extsk_rust);
+     //       warn!("bech32 decode: result({:?})", result);
+     //   } else {
+     //       warn!("extsk JString was empty!!");
+     //   }
 
         let hd_seed = env.convert_byte_array(seed).unwrap();
         //warn!("Jni boundary, seed: {:?}, length: {}", hd_seed, hd_seed.len());
@@ -404,7 +416,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createAcc
             })?;
 
         let (account_id, usk) = db_data
-            .create_account(&transparent_key, &seed, &birthday)
+            .create_account(&transparent_key, &extsk, &seed, &birthday)
             .map_err(|e| anyhow!("Error while initializing accounts: {}", e))?;
 
         let account = db_data.get_account(account_id)?.expect("just created");
@@ -427,6 +439,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_isSeedRel
     _: JClass<'local>,
     db_data: JString<'local>,
     transparent_key: JByteArray<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     network_id: jint,
 ) -> jboolean {
@@ -434,10 +447,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_isSeedRel
         let network = parse_network(network_id as u32)?;
         let db_data = wallet_db(env, network, db_data)?;
         let transparent_key = SecretVec::new(env.convert_byte_array(transparent_key).unwrap());
+        let extsk = SecretVec::new(env.convert_byte_array(extsk).unwrap());
         let seed = SecretVec::new(env.convert_byte_array(seed).unwrap());
 
         // Replicate the logic from `initWalletDb`.
-        Ok(match db_data.seed_relevance_to_derived_accounts(&transparent_key, &seed)? {
+        Ok(match db_data.seed_relevance_to_derived_accounts(&transparent_key, &extsk, &seed)? {
             SeedRelevance::Relevant { .. } | SeedRelevance::NoAccounts => JNI_TRUE,
             SeedRelevance::NotRelevant | SeedRelevance::NoDerivedAccounts => JNI_FALSE,
         })
@@ -457,6 +471,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     transparent_key: JByteArray<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     account: jint,
     network_id: jint,
@@ -465,10 +480,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
         let _span = tracing::info_span!("RustDerivationTool.deriveSpendingKey").entered();
         let network = parse_network(network_id as u32)?;
         let transparent_key = SecretVec::new(env.convert_byte_array(transparent_key).unwrap_or(Vec::new()));
-        let seed = SecretVec::new(env.convert_byte_array(seed).unwrap());
+        let extsk = SecretVec::new(env.convert_byte_array(extsk).unwrap_or(Vec::new()));
+        let seed = SecretVec::new(env.convert_byte_array(seed).unwrap_or(Vec::new()));
         let account = account_id_from_jint(account)?;
 
-        let usk = UnifiedSpendingKey::from_seed(&network, transparent_key.expose_secret(), seed.expose_secret(), account)
+        let usk = UnifiedSpendingKey::from_seed(&network, transparent_key.expose_secret(), extsk.expose_secret(), seed.expose_secret(), account)
             .map_err(|e| anyhow!("error generating unified spending key from seed: {:?}", e))?;
 
         //warn!("Seed({:?}), usk({:?})", seed.expose_secret(), usk);
@@ -494,7 +510,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
         let seed = SecretVec::new(env.convert_byte_array(seed).unwrap());
         let account = account_id_from_jint(account)?;
 
-        let usk = UnifiedSpendingKey::from_seed(&network, &[], seed.expose_secret(), account)
+        let usk = UnifiedSpendingKey::from_seed(&network, &[], &[], seed.expose_secret(), account)
             .map_err(|e| anyhow!("error generating unified spending key from seed: {:?}", e)).expect("Unable to convert usk to sapling extsk");
         let extsk = usk.sapling();
 
@@ -510,6 +526,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     transparent_key: JByteArray<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     accounts: jint,
     network_id: jint,
@@ -519,6 +536,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
             .entered();
         let network = parse_network(network_id as u32)?;
         let transparent_key = env.convert_byte_array(transparent_key)?;
+        let extsk = env.convert_byte_array(extsk)?;
         let seed = env.convert_byte_array(seed).unwrap();
         let accounts = if accounts > 0 {
             accounts as u32
@@ -530,7 +548,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
             .map(|account| {
                 let account_id = zip32::AccountId::try_from(account)
                     .map_err(|_| anyhow!("Invalid account ID"))?;
-                UnifiedSpendingKey::from_seed(&network, &transparent_key, &seed, account_id)
+                UnifiedSpendingKey::from_seed(&network, &transparent_key, &extsk, &seed, account_id)
                     .map_err(|e| {
                         anyhow!("error generating unified spending key from seed: {:?}", e)
                     })
@@ -556,6 +574,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
 >(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     accounts: jint,
     network_id: jint,
@@ -564,7 +583,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
         let _span = tracing::info_span!("RustDerivationTool.deriveViewingKey")
             .entered();
         let network = parse_network(network_id as u32)?;
-        let seed = env.convert_byte_array(seed).unwrap();
+        let extsk = env.convert_byte_array(extsk)?;
+        let seed = env.convert_byte_array(seed)?;
         let accounts = if accounts > 0 {
             accounts as u32
         } else {
@@ -575,7 +595,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
             .map(|account| {
                 let account_id = zip32::AccountId::try_from(account)
                     .map_err(|_| anyhow!("Invalid account ID"))?;
-                UnifiedSpendingKey::from_seed(&network, &[], &seed, account_id)
+                UnifiedSpendingKey::from_seed(&network, &[], &extsk, &seed, account_id)
                     .map_err(|e| {
                         anyhow!("error generating unified spending key from seed: {:?}", e)
                     })
@@ -604,6 +624,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     transparent_key: JByteArray<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     account_index: jint,
     network_id: jint,
@@ -613,10 +634,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
             tracing::info_span!("RustDerivationTool.deriveUnifiedAddressFromSeed").entered();
         let network = parse_network(network_id as u32)?;
         let transparent_key = env.convert_byte_array(transparent_key)?;
+        let extsk = env.convert_byte_array(extsk)?;
         let seed = env.convert_byte_array(seed).unwrap();
         let account_id = account_id_from_jint(account_index)?;
 
-        let ufvk = UnifiedSpendingKey::from_seed(&network, &transparent_key, &seed, account_id)
+        let ufvk = UnifiedSpendingKey::from_seed(&network, &transparent_key, &extsk, &seed, account_id)
             .map_err(|e| anyhow!("error generating unified spending key from seed: {:?}", e))
             .map(|usk| usk.to_unified_full_viewing_key())?;
 
@@ -638,6 +660,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
 >(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
+    extsk: JByteArray<'local>,
     seed: JByteArray<'local>,
     account_index: jint,
     network_id: jint,
@@ -646,10 +669,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
         let _span =
             tracing::info_span!("RustDerivationTool.deriveShieldedAddressFromSeed").entered();
         let network = parse_network(network_id as u32)?;
-        let seed = env.convert_byte_array(seed).unwrap();
+        let seed = env.convert_byte_array(seed)?;
+        let extsk = env.convert_byte_array(extsk)?;
         let account_id = account_id_from_jint(account_index)?;
 
-        let ufvk = UnifiedSpendingKey::from_seed(&network, &[], &seed, account_id)
+        let ufvk = UnifiedSpendingKey::from_seed(&network, &[], &extsk, &seed, account_id)
             .map_err(|e| anyhow!("error generating unified spending key from seed: {:?}", e))
             .map(|usk| usk.to_unified_full_viewing_key())?;
 

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -265,18 +265,20 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_initDataD
         let mut db_data = wallet_db(env, network, db_data)
             .map_err(|e| anyhow!("Error while opening data DB: {}", e))?;
 
-        if (seed.is_null() && extsk.is_null()) {
-            // throw error
-        }
-
-        if (!seed.is_null() && !extsk.is_null()) {
-            // throw error
-        }
-
         let seed = (!seed.is_null()).then(|| SecretVec::new(env.convert_byte_array(seed).unwrap()));
-
         let extsk = (!extsk.is_null()).then(|| SecretVec::new(env.convert_byte_array(extsk).unwrap()));
+/*
+        let seed_empty = seed.unwrap_or(SecretVec::new(Vec::<u8>::new())).expose_secret().is_empty();
+        let extsk_empty = extsk.unwrap_or(SecretVec::new(Vec::<u8>::new())).expose_secret().is_empty();
 
+        if seed_empty && extsk_empty {
+            return Err(anyhow!("Error: neither seed nor extsk were provided for initializing DB. Choose one!"));
+        }
+        if !seed_empty && !extsk_empty {
+           // warn!("seed = {:?}, extsk = {:?}", seed, extsk);
+            return Err(anyhow!("Error: cannot initialize database with extsk and seed. Choose one!"));
+        }
+*/
         let transparent_key = (!transparent_key.is_null()).then(|| SecretVec::new(env.convert_byte_array(transparent_key).unwrap()));
 
         match init_wallet_db(&mut db_data, transparent_key, extsk, seed) {
@@ -926,7 +928,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_isValidSp
 }
 
 #[no_mangle]
-pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_isValidSaplingAddress<
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_isValidSaplingAddress<
     'local,
 >(
     mut env: JNIEnv<'local>,

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -5,8 +5,7 @@ use std::panic;
 use std::path::Path;
 use std::ptr;
 
-use tracing::warn;
-use zcash_primitives::constants::vrsc::mainnet;
+//use tracing::warn;
 
 use anyhow::anyhow;
 use jni::objects::{JByteArray, JObject, JObjectArray, JValue};
@@ -66,8 +65,6 @@ use zcash_client_backend::{
     zip321::{Payment, TransactionRequest},
     ShieldedProtocol,
 };
-
-use zcash_client_backend::encoding::decode_extended_spending_key;
 
 use zcash_client_sqlite::{
     chain::{init::init_blockmeta_db, BlockMeta},

--- a/sdk-incubator-lib/src/androidTest/kotlin/cash/z/ecc/android/sdk/fixture/PersistableWalletFixture.kt
+++ b/sdk-incubator-lib/src/androidTest/kotlin/cash/z/ecc/android/sdk/fixture/PersistableWalletFixture.kt
@@ -20,6 +20,8 @@ object PersistableWalletFixture {
 
     val WIF = ""
 
+    val EXTSK = ""
+
     val decodedWif = WIF.decodeBase58WithChecksum()
 
     val transparentKey = decodedWif.copyOfRange(1, decodedWif.size)
@@ -34,8 +36,9 @@ object PersistableWalletFixture {
         birthday: BlockHeight = BIRTHDAY,
         seedPhrase: SeedPhrase = SEED_PHRASE,
         walletInitMode: WalletInitMode = WALLET_INIT_MODE,
-        wif: String? = WIF
-    ) = PersistableWallet(network, endpoint, birthday, seedPhrase, walletInitMode, wif)
+        wif: String? = WIF,
+        extsk: String? = EXTSK
+    ) = PersistableWallet(network, endpoint, birthday, seedPhrase, walletInitMode, wif, extsk)
 
     fun persistVersionOne() =
         PersistableWallet.toCustomJson(
@@ -44,6 +47,7 @@ object PersistableWalletFixture {
             endpoint = null,
             birthday = BIRTHDAY,
             seed = SEED_PHRASE,
-            wif = WIF
+            wif = WIF,
+            extsk = EXTSK
         )
 }

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/WalletCoordinator.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/WalletCoordinator.kt
@@ -83,7 +83,8 @@ class WalletCoordinator(
                                 birthday = persistableWallet.birthday,
                                 seed = persistableWallet.hexSeed.decodeHex(),
                                 walletInitMode = persistableWallet.walletInitMode,
-                                transparentKey = persistableWallet.wif?.decodeBase58WithChecksum()?.copyOfRange(1,34)
+                                transparentKey = persistableWallet.wif?.decodeBase58WithChecksum()?.copyOfRange(1,34),
+                                extsk = persistableWallet.extsk?.decodeHex()
                             )
 
                         trySend(InternalSynchronizerStatus.Available(closeableSynchronizer))

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
@@ -18,17 +18,21 @@ sealed class WalletFixture {
 
     abstract val wifString: String
 
+    abstract val extskString: String
+
     abstract fun getBirthday(zcashNetwork: ZcashNetwork): BlockHeight
 
     abstract fun getAddresses(zcashNetwork: ZcashNetwork): Addresses
 
     suspend fun getUnifiedSpendingKey(
         wif: ByteArray = wifString.decodeBase58WithChecksum().copyOfRange(1,34), //TODO: don't use hardcoded ints
+//        extsk: String = extskString,
         seed: String = hexSeed,
         network: ZcashNetwork,
         account: Account = Account.DEFAULT
     ) = DerivationTool.getInstance().deriveUnifiedSpendingKey(
         wif,
+ //       extsk.decodeHex(),
         seed.decodeHex(),
         network,
         account
@@ -38,6 +42,8 @@ sealed class WalletFixture {
     object Ben : WalletFixture() {
 
         override val wifString = ""
+
+        override val extskString = ""
 
         override val hexSeed: String
             get() = "dc064f1e2a1aa6a9f349b92b459f6ca9e6b598faf8de373059958c1f99b4770a"
@@ -86,6 +92,9 @@ sealed class WalletFixture {
 
 	override val wifString: String
 	    get() = "UxUY1K87of2ntgchEprKosZVt97DXPv4iZP6oGkcxXdVFNtbncMT"
+
+	override val extskString: String
+	    get() = ""
 
         override val hexSeed: String
             get() = "dc064f1e2a1aa6a9f349b92b459f6ca9e6b598faf8de373059958c1f99b4770a"

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
@@ -26,13 +26,13 @@ sealed class WalletFixture {
 
     suspend fun getUnifiedSpendingKey(
         wif: ByteArray = wifString.decodeBase58WithChecksum().copyOfRange(1,34), //TODO: don't use hardcoded ints
-//        extsk: String = extskString,
+        extsk: String = extskString,
         seed: String = hexSeed,
         network: ZcashNetwork,
         account: Account = Account.DEFAULT
     ) = DerivationTool.getInstance().deriveUnifiedSpendingKey(
         wif,
- //       extsk.decodeHex(),
+        extsk.decodeHex(),
         seed.decodeHex(),
         network,
         account

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/PersistableWallet.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/PersistableWallet.kt
@@ -30,7 +30,8 @@ data class PersistableWallet(
     //val seedPhrase: seedPhrase,
     val hexSeed: String,
     val walletInitMode: WalletInitMode,
-    val wif: String?
+    val wif: String?,
+    val extsk: String?
 ) {
     init {
         walletInitModeHolder = walletInitMode
@@ -56,6 +57,9 @@ data class PersistableWallet(
             put(KEY_HEX_SEED, hexSeed)
             wif?.let {
                 put(KEY_WIF, wif)
+            }
+            extsk?.let {
+                put(KEY_EXTSK, extsk)
             }
         }
 
@@ -85,6 +89,7 @@ data class PersistableWallet(
 //        internal const val KEY_SEED_PHRASE = "seed_phrase"
         internal const val KEY_HEX_SEED = "hex_seed"
         internal const val KEY_WIF = "wif"
+        internal const val KEY_EXTSK = "extsk"
 
         // Note: [walletInitMode] is excluded from the serialization to avoid persisting the wallet initialization mode
         // with the persistable wallet.
@@ -100,6 +105,7 @@ data class PersistableWallet(
             val endpoint: LightWalletEndpoint
 
             val wif = getWif(jsonObject)
+            val extsk = getExtsk(jsonObject)
 
             when (val version = getVersion(jsonObject)) {
                 VERSION_1 -> {
@@ -119,7 +125,8 @@ data class PersistableWallet(
                 birthday = birthday,
                 hexSeed = hexSeed,
                 walletInitMode = walletInitModeHolder,
-                wif = wif
+                wif = wif,
+                extsk = extsk
             )
         }
 
@@ -138,6 +145,14 @@ data class PersistableWallet(
         internal fun getWif(jsonObject: JSONObject): String? {
             return if (jsonObject.has(KEY_WIF)) {
                 jsonObject.getString(KEY_WIF)
+            } else {
+                null
+            }
+        }
+
+        internal fun getExtsk(jsonObject: JSONObject): String? {
+            return if (jsonObject.has(KEY_EXTSK)) {
+                jsonObject.getString(KEY_EXTSK)
             } else {
                 null
             }
@@ -191,6 +206,7 @@ data class PersistableWallet(
             val hexSeed = newRawHDSeed()
 
             val wif = null
+            val extsk = null
 
             return PersistableWallet(
                 zcashNetwork,
@@ -198,7 +214,8 @@ data class PersistableWallet(
                 birthday,
                 hexSeed,
                 walletInitMode,
-                wif
+                wif,
+                extsk
             )
         }
 
@@ -214,7 +231,8 @@ data class PersistableWallet(
             endpoint: LightWalletEndpoint?,
             birthday: BlockHeight?,
             seed: String,
-            wif: String?
+            wif: String?,
+            extsk: String?
         ) = JSONObject().apply {
             put(KEY_VERSION, version)
             put(KEY_NETWORK_ID, network.id)
@@ -230,6 +248,9 @@ data class PersistableWallet(
             put(KEY_HEX_SEED, seed)
             wif?.let {
                 put(KEY_WIF, wif)
+           }
+            extsk?.let {
+                put(KEY_EXTSK, extsk)
            }
         }
     }

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/SeedPhrase.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/SeedPhrase.kt
@@ -27,7 +27,6 @@ data class SeedPhrase(val split: List<String>) {
 
     suspend fun toByteArray() = withContext(Dispatchers.IO) { 
         if (HEX_SEED_SIZE == split.size) {
-            Log.w("SeedPhrase", "Seed value: $split.first()" ); 
             split.first().decodeHex()            
         } else {
             Mnemonics.MnemonicCode(joinToString()).toSeed()

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/SeedPhrase.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/SeedPhrase.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.bip39.Mnemonics
 import cash.z.ecc.android.bip39.toSeed
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import android.util.Log
 
 // Consider using ImmutableList here
 data class SeedPhrase(val split: List<String>) {
@@ -20,12 +21,13 @@ data class SeedPhrase(val split: List<String>) {
     }
 
     // For security, intentionally override the toString method to reduce risk of accidentally logging secrets
-    override fun toString() = "SeedPhrase"
+    //override fun toString() = "SeedPhrase"
 
     fun joinToString() = split.joinToString(DEFAULT_DELIMITER)
 
     suspend fun toByteArray() = withContext(Dispatchers.IO) { 
         if (HEX_SEED_SIZE == split.size) {
+            Log.w("SeedPhrase", "Seed value: $split.first()" ); 
             split.first().decodeHex()            
         } else {
             Mnemonics.MnemonicCode(joinToString()).toSeed()

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/SeedPhrase.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/SeedPhrase.kt
@@ -21,7 +21,7 @@ data class SeedPhrase(val split: List<String>) {
     }
 
     // For security, intentionally override the toString method to reduce risk of accidentally logging secrets
-    //override fun toString() = "SeedPhrase"
+    override fun toString() = "SeedPhrase"
 
     fun joinToString() = split.joinToString(DEFAULT_DELIMITER)
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -541,7 +541,7 @@ class SdkSynchronizer private constructor(
     // Not ready to be a public API; internal for testing only
     internal suspend fun createAccount(
         transparentKey: ByteArray,
-        extsk: String,
+        extsk: ByteArray,
         seed: ByteArray,
         treeState: TreeState,
         recoverUntil: BlockHeight?
@@ -904,7 +904,7 @@ internal object DefaultSynchronizerFactory {
         numberOfAccounts: Int,
         recoverUntil: BlockHeight?,
         transparentKey: ByteArray?,
-        extsk: String?
+        extsk: ByteArray?
     ): DerivedDataRepository =
         DbDerivedDataRepository(
             DerivedDataDb.new(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -541,6 +541,7 @@ class SdkSynchronizer private constructor(
     // Not ready to be a public API; internal for testing only
     internal suspend fun createAccount(
         transparentKey: ByteArray,
+        extsk: String,
         seed: ByteArray,
         treeState: TreeState,
         recoverUntil: BlockHeight?
@@ -548,6 +549,7 @@ class SdkSynchronizer private constructor(
         return runCatching {
             backend.createAccountAndGetSpendingKey(
                 transparentKey = transparentKey,
+                extsk = extsk,
                 seed = seed,
                 treeState = treeState,
                 recoverUntil = recoverUntil
@@ -901,7 +903,8 @@ internal object DefaultSynchronizerFactory {
         seed: ByteArray?,
         numberOfAccounts: Int,
         recoverUntil: BlockHeight?,
-        transparentKey: ByteArray?
+        transparentKey: ByteArray?,
+        extsk: String?
     ): DerivedDataRepository =
         DbDerivedDataRepository(
             DerivedDataDb.new(
@@ -911,6 +914,7 @@ internal object DefaultSynchronizerFactory {
                 zcashNetwork,
                 checkpoint,
                 transparentKey,
+                extsk,
                 seed,
                 numberOfAccounts,
                 recoverUntil

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -581,7 +581,7 @@ interface Synchronizer {
             birthday: BlockHeight?,
             walletInitMode: WalletInitMode,
             transparentKey: ByteArray?,
-            extsk: String?
+            extsk: ByteArray?
         ): CloseableSynchronizer {
             val applicationContext = context.applicationContext
 
@@ -691,7 +691,7 @@ interface Synchronizer {
             birthday: BlockHeight?,
             walletInitMode: WalletInitMode,
             transparentKey: ByteArray?,
-            extsk: String?
+            extsk: ByteArray?
         ): CloseableSynchronizer =
             runBlocking {
                 new(context, zcashNetwork, alias, lightWalletEndpoint, seed, birthday, walletInitMode, transparentKey, extsk)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -580,7 +580,8 @@ interface Synchronizer {
             seed: ByteArray?,
             birthday: BlockHeight?,
             walletInitMode: WalletInitMode,
-            transparentKey: ByteArray?
+            transparentKey: ByteArray?,
+            extsk: String?
         ): CloseableSynchronizer {
             val applicationContext = context.applicationContext
 
@@ -643,6 +644,7 @@ interface Synchronizer {
                     zcashNetwork = zcashNetwork,
                     checkpoint = loadedCheckpoint,
                     transparentKey = transparentKey,
+                    extsk = extsk,
                     seed = seed,
                     numberOfAccounts = Derivation.DEFAULT_NUMBER_OF_ACCOUNTS,
                     recoverUntil = chainTip
@@ -688,10 +690,11 @@ interface Synchronizer {
             seed: ByteArray?,
             birthday: BlockHeight?,
             walletInitMode: WalletInitMode,
-            transparentKey: ByteArray
+            transparentKey: ByteArray?,
+            extsk: String?
         ): CloseableSynchronizer =
             runBlocking {
-                new(context, zcashNetwork, alias, lightWalletEndpoint, seed, birthday, walletInitMode, transparentKey)
+                new(context, zcashNetwork, alias, lightWalletEndpoint, seed, birthday, walletInitMode, transparentKey, extsk)
             }
 
         /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/DerivationToolExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/DerivationToolExt.kt
@@ -32,10 +32,11 @@ fun Derivation.deriveShieldedAddress(
 
 fun Derivation.deriveUnifiedSpendingKey(
     transparentKey: ByteArray,
+    extendedSecretKey: ByteArray,
     seed: ByteArray,
     network: ZcashNetwork,
     account: Account
-): UnifiedSpendingKey = UnifiedSpendingKey(deriveUnifiedSpendingKey(transparentKey, seed, network.id, account.value))
+): UnifiedSpendingKey = UnifiedSpendingKey(deriveUnifiedSpendingKey(transparentKey, extendedSecretKey, seed, network.id, account.value))
 
 
 fun Derivation.deriveSaplingSpendingKey(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -22,8 +22,8 @@ internal interface TypesafeBackend {
 
     suspend fun createAccountAndGetSpendingKey(
         transparentKey: ByteArray?,
-        extsk: String?,
-        seed: ByteArray,
+        extsk: ByteArray?,
+        seed: ByteArray?,
         treeState: TreeState,
         recoverUntil: BlockHeight?
     ): UnifiedSpendingKey
@@ -83,7 +83,7 @@ internal interface TypesafeBackend {
     ): String?
 
     @Throws(InitializeException::class)
-    suspend fun initDataDb(transparentKey: ByteArray?, seed: ByteArray?)
+    suspend fun initDataDb(transparentKey: ByteArray?, extsk: ByteArray?, seed: ByteArray?)
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -85,6 +85,9 @@ internal interface TypesafeBackend {
     @Throws(InitializeException::class)
     suspend fun initDataDb(transparentKey: ByteArray?, extsk: ByteArray?, seed: ByteArray?)
 
+/*  @Throws(RuntimeException::class)
+    suspend fun deleteDb(clearCache: Boolean, clearDataDb: Boolean)
+*/
     /**
      * @throws RuntimeException as a common indicator of the operation failure
      */

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -22,6 +22,7 @@ internal interface TypesafeBackend {
 
     suspend fun createAccountAndGetSpendingKey(
         transparentKey: ByteArray?,
+        extsk: String?,
         seed: ByteArray,
         treeState: TreeState,
         recoverUntil: BlockHeight?

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -1,6 +1,7 @@
 package cash.z.ecc.android.sdk.internal
 
 import cash.z.ecc.android.sdk.exception.InitializeException
+import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.JniSubtreeRoot
 import cash.z.ecc.android.sdk.internal.model.ScanRange
@@ -172,6 +173,17 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
         }
     }
 
+/*    override suspend fun deleteDb(
+        clearCache: Boolean,
+        clearDataDb: Boolean
+    ): Boolean {
+        val ret = backend.clear(clearCache, clearDataDb)
+        if (ret == false) {
+            throw CompactBlockProcessorException.FailedDeleteException
+        }
+        return ret
+    }
+*/
     override suspend fun putSubtreeRoots(
         saplingStartIndex: UInt,
         saplingRoots: List<SubtreeRoot>,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -25,8 +25,8 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
 
     override suspend fun createAccountAndGetSpendingKey(
         transparentKey: ByteArray?,
-        extsk: String?,
-        seed: ByteArray,
+        extsk: ByteArray?,
+        seed: ByteArray?,
         treeState: TreeState,
         recoverUntil: BlockHeight?
     ): UnifiedSpendingKey {
@@ -161,8 +161,8 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
             outputIndex = outputIndex
         )
 
-    override suspend fun initDataDb(transparentKey: ByteArray?, seed: ByteArray?) {
-        val ret = backend.initDataDb(transparentKey, seed)
+    override suspend fun initDataDb(transparentKey: ByteArray?, extsk: ByteArray?, seed: ByteArray?) {
+        val ret = backend.initDataDb(transparentKey, extsk, seed)
         when (ret) {
             2 -> throw InitializeException.SeedNotRelevant
             1 -> throw InitializeException.SeedRequired

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -25,6 +25,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
 
     override suspend fun createAccountAndGetSpendingKey(
         transparentKey: ByteArray?,
+        extsk: String?,
         seed: ByteArray,
         treeState: TreeState,
         recoverUntil: BlockHeight?
@@ -32,6 +33,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
         return UnifiedSpendingKey(
             backend.createAccount(
                 transparentKey = transparentKey,
+                extsk = extsk,
                 seed = seed,
                 treeState = treeState.encoded,
                 recoverUntil = recoverUntil?.value

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeDerivationToolImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeDerivationToolImpl.kt
@@ -27,10 +27,11 @@ internal class TypesafeDerivationToolImpl(private val derivation: Derivation) : 
 */
     override suspend fun deriveUnifiedSpendingKey(
         transparentKey: ByteArray,
+        extendedSecretKey: ByteArray,
         seed: ByteArray,
         network: ZcashNetwork,
         account: Account
-    ): UnifiedSpendingKey = derivation.deriveUnifiedSpendingKey(transparentKey, seed, network, account)
+    ): UnifiedSpendingKey = derivation.deriveUnifiedSpendingKey(transparentKey, extendedSecretKey, seed, network, account)
 
 
     override suspend fun deriveSaplingSpendingKey(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/DatabaseCoordinator.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/DatabaseCoordinator.kt
@@ -178,11 +178,19 @@ internal class DatabaseCoordinator private constructor(context: Context) {
         alias: String
     ): Boolean {
         deleteFileMutex.withLock {
+            val dataDb = dataDbFile(network, alias)
+
+            Twig.info { "DataDbFile: ${dataDb}" }
+
             val dataDeleted = deleteDatabase(dataDbFile(network, alias))
+
+            val blockDbRoot = fsBlockDbRoot(network, alias)
+
+            Twig.info { "blockDbRoot: $blockDbRoot" }
 
             val cacheDeleted = fsBlockDbRoot(network, alias).deleteRecursivelySuspend()
 
-            Twig.info { "Delete databases result: ${dataDeleted || cacheDeleted}" }
+            Twig.info { "Delete databases result: dataDeleted(${dataDeleted}), cacheDeleted(${cacheDeleted})" }
 
             return dataDeleted || cacheDeleted
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DerivedDataDb.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DerivedDataDb.kt
@@ -48,6 +48,7 @@ internal class DerivedDataDb private constructor(
             zcashNetwork: ZcashNetwork,
             checkpoint: Checkpoint,
             transparentKey: ByteArray?,
+            extsk: String?,
             seed: ByteArray?,
             numberOfAccounts: Int,
             recoverUntil: BlockHeight?
@@ -77,6 +78,7 @@ internal class DerivedDataDb private constructor(
                     runCatching {
                         backend.createAccountAndGetSpendingKey(
                             transparentKey = transparentKey,
+                            extsk = extsk,
                             seed = checkedSeed,
                             treeState = checkpoint.treeState(),
                             recoverUntil = recoverUntil

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DerivedDataDb.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DerivedDataDb.kt
@@ -48,12 +48,12 @@ internal class DerivedDataDb private constructor(
             zcashNetwork: ZcashNetwork,
             checkpoint: Checkpoint,
             transparentKey: ByteArray?,
-            extsk: String?,
+            extsk: ByteArray?,
             seed: ByteArray?,
             numberOfAccounts: Int,
             recoverUntil: BlockHeight?
         ): DerivedDataDb {
-            backend.initDataDb(transparentKey, seed)
+            backend.initDataDb(transparentKey, extsk, seed)
 
             val database =
                 ReadOnlySupportSqliteOpenHelper.openExistingDatabaseAsReadOnly(
@@ -68,6 +68,9 @@ internal class DerivedDataDb private constructor(
             val dataDb = DerivedDataDb(zcashNetwork, database)
 
             // If a seed is provided, fill in the accounts.
+ 
+           // TODO: handle extsk here?
+
             seed?.let { checkedSeed ->
                 // toInt() should be safe because we expect very few accounts
                 val missingAccounts = numberOfAccounts - dataDb.accountTable.count().toInt()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/Bech32.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/Bech32.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cash.z.ecc.android.sdk.model
+
+import kotlin.jvm.JvmStatic
+
+/**
+ * Bech32 works with 5 bits values, we use this type to make it explicit: whenever you see Int5 it means 5 bits values,
+ * and whenever you see Byte it means 8 bits values.
+ */
+public typealias Int5 = Byte
+
+/**
+ * Bech32 and Bech32m address formats.
+ * See https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki and https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki.
+ */
+public object Bech32 {
+    public const val alphabet: String = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+    public enum class Encoding(public val constant: Int) {
+        Bech32(1),
+        Bech32m(0x2bc830a3),
+        Beck32WithoutChecksum(0),
+    }
+
+    // char -> 5 bits value
+    private val map = Array<Int5>(255) { -1 }
+
+    init {
+        for (i in 0..alphabet.lastIndex) {
+            map[alphabet[i].code] = i.toByte()
+        }
+    }
+
+    private fun expand(hrp: String): Array<Int5> {
+        val result = Array<Int5>(hrp.length + 1 + hrp.length) { 0 }
+        for (i in hrp.indices) {
+            result[i] = hrp[i].code.shr(5).toByte()
+            result[hrp.length + 1 + i] = (hrp[i].code and 31).toByte()
+        }
+        result[hrp.length] = 0
+        return result
+    }
+
+    private fun polymod(values: Array<Int5>, values1: Array<Int5>): Int {
+        val GEN = arrayOf(0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3)
+        var chk = 1
+        values.forEach { v ->
+            val b = chk shr 25
+            chk = ((chk and 0x1ffffff) shl 5) xor v.toInt()
+            for (i in 0..5) {
+                if (((b shr i) and 1) != 0) chk = chk xor GEN[i]
+            }
+        }
+        values1.forEach { v ->
+            val b = chk shr 25
+            chk = ((chk and 0x1ffffff) shl 5) xor v.toInt()
+            for (i in 0..5) {
+                if (((b shr i) and 1) != 0) chk = chk xor GEN[i]
+            }
+        }
+        return chk
+    }
+
+    /**
+     * @param hrp human readable prefix
+     * @param int5s 5-bit data
+     * @param encoding encoding to use (bech32 or bech32m)
+     * @return hrp + data encoded as a Bech32 string
+     */
+    @JvmStatic
+    public fun encode(hrp: String, int5s: Array<Int5>, encoding: Encoding): String {
+        require(hrp.lowercase() == hrp || hrp.uppercase() == hrp) { "mixed case strings are not valid bech32 prefixes" }
+        val data = int5s.toByteArray().toTypedArray()
+        val checksum = when (encoding) {
+            Encoding.Beck32WithoutChecksum -> arrayOf()
+            else -> checksum(hrp, data, encoding)
+        }
+        return hrp + "1" + (data + checksum).map { i -> alphabet[i.toInt()] }.toCharArray().concatToString()
+    }
+
+    /**
+     * @param hrp human readable prefix
+     * @param data data to encode
+     * @param encoding encoding to use (bech32 or bech32m)
+     * @return hrp + data encoded as a Bech32 string
+     */
+    @JvmStatic
+    public fun encodeBytes(hrp: String, data: ByteArray, encoding: Encoding): String = encode(hrp, eight2five(data), encoding)
+
+    /**
+     * decodes a bech32 string
+     * @param bech32 bech32 string
+     * @param noChecksum if true, the bech32 string doesn't have a checksum
+     * @return a (hrp, data, encoding) tuple
+     */
+    @JvmStatic
+    public fun decode(bech32: String, noChecksum: Boolean = false): Triple<String, Array<Int5>, Encoding> {
+        require(bech32.lowercase() == bech32 || bech32.uppercase() == bech32) { "mixed case strings are not valid bech32" }
+        bech32.forEach { require(it.code in 33..126) { "invalid character " } }
+        val input = bech32.lowercase()
+        val pos = input.lastIndexOf('1')
+        val hrp = input.take(pos)
+        require(hrp.length in 1..83) { "hrp must contain 1 to 83 characters" }
+        val data = Array<Int5>(input.length - pos - 1) { 0 }
+        for (i in 0..data.lastIndex) data[i] = map[input[pos + 1 + i].code]
+        return if (noChecksum) {
+            Triple(hrp, data, Encoding.Beck32WithoutChecksum)
+        } else {
+            val encoding = when (polymod(expand(hrp), data)) {
+                Encoding.Bech32.constant -> Encoding.Bech32
+                Encoding.Bech32m.constant -> Encoding.Bech32m
+                else -> throw IllegalArgumentException("invalid checksum for $bech32")
+            }
+            Triple(hrp, data.dropLast(6).toTypedArray(), encoding)
+        }
+    }
+
+    /**
+     * decodes a bech32 string
+     * @param bech32 bech32 string
+     * @param noChecksum if true, the bech32 string doesn't have a checksum
+     * @return a (hrp, data, encoding) tuple
+     */
+    @JvmStatic
+    public fun decodeBytes(bech32: String, noChecksum: Boolean = false): Triple<String, ByteArray, Encoding> {
+        val (hrp, int5s, encoding) = decode(bech32, noChecksum)
+        return Triple(hrp, five2eight(int5s, 0), encoding)
+    }
+
+    /**
+     * @param hrp Human Readable Part
+     * @param data data (a sequence of 5 bits integers)
+     * @param encoding encoding to use (bech32 or bech32m)
+     * @return a checksum computed over hrp and data
+     */
+    private fun checksum(hrp: String, data: Array<Int5>, encoding: Encoding): Array<Int5> {
+        val values = expand(hrp) + data
+        val poly = polymod(values, arrayOf(0.toByte(), 0.toByte(), 0.toByte(), 0.toByte(), 0.toByte(), 0.toByte())) xor encoding.constant
+        return Array(6) { i -> (poly.shr(5 * (5 - i)) and 31).toByte() }
+    }
+
+    /**
+     * @param input a sequence of 8 bits integers
+     * @return a sequence of 5 bits integers
+     */
+    @JvmStatic
+    public fun eight2five(input: ByteArray): Array<Int5> {
+        var buffer = 0L
+        val output = ArrayList<Int5>()
+        var count = 0
+        input.forEach { b ->
+            buffer = (buffer shl 8) or (b.toLong() and 0xff)
+            count += 8
+            while (count >= 5) {
+                output.add(((buffer shr (count - 5)) and 31).toByte())
+                count -= 5
+            }
+        }
+        if (count > 0) output.add(((buffer shl (5 - count)) and 31).toByte())
+        return output.toTypedArray()
+    }
+
+    /**
+     * @param input a sequence of 5 bits integers
+     * @return a sequence of 8 bits integers
+     */
+    @JvmStatic
+    public fun five2eight(input: Array<Int5>, offset: Int): ByteArray {
+        var buffer = 0L
+        val output = ArrayList<Byte>()
+        var count = 0
+        for (i in offset..input.lastIndex) {
+            val b = input[i]
+            buffer = (buffer shl 5) or (b.toLong() and 31)
+            count += 5
+            while (count >= 8) {
+                output.add(((buffer shr (count - 8)) and 0xff).toByte())
+                count -= 8
+            }
+        }
+        require(count <= 4) { "Zero-padding of more than 4 bits" }
+        require((buffer and ((1L shl count) - 1L)) == 0L) { "Non-zero padding in 8-to-5 conversion" }
+        return output.toByteArray()
+    }
+
+    /**
+     * encode a bitcoin witness address
+     * @param hrp should be "bc" or "tb"
+     * @param witnessVersion witness version (0 to 16)
+     * @param data witness program: if version is 0, either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
+     * @return a bech32 encoded witness address
+     */
+    @JvmStatic
+    public fun encodeWitnessAddress(hrp: String, witnessVersion: Byte, data: ByteArray): String {
+        require(witnessVersion in 0..16) { "invalid segwit version" }
+        val encoding = when (witnessVersion) {
+            0.toByte() -> Encoding.Bech32
+            else -> Encoding.Bech32m
+        }
+        val data1 = arrayOf(witnessVersion) + eight2five(data)
+        val checksum = checksum(hrp, data1, encoding)
+        val chars = (data1 + checksum).map { i -> alphabet[i.toInt()] }
+        val sb = StringBuilder()
+        for (c in chars) sb.append(c)
+        return hrp + "1" + sb.toString()
+    }
+
+    /**
+     * decode a bitcoin witness address
+     * @param address witness address
+     * @return a (prefix, version, program) tuple where prefix is the human-readable prefix, version is the witness version and program the decoded witness program.
+     *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH).
+     */
+    @JvmStatic
+    public fun decodeWitnessAddress(address: String): Triple<String, Byte, ByteArray> {
+        val (hrp, data, encoding) = decode(address)
+        require(hrp == "bc" || hrp == "tb" || hrp == "bcrt") { "invalid HRP $hrp" }
+        val version = data[0]
+        require(version in 0..16) { "invalid segwit version" }
+        val bin = five2eight(data, 1)
+        require(bin.size in 2..40) { "invalid witness program length ${bin.size}" }
+        if (version == 0.toByte()) require(encoding == Encoding.Bech32) { "version 0 must be encoded with Bech32" }
+        if (version == 0.toByte()) require(bin.size == 20 || bin.size == 32) { "invalid witness program length ${bin.size}" }
+        if (version != 0.toByte()) require(encoding == Encoding.Bech32m) { "version 1 to 16 must be encoded with Bech32m" }
+        return Triple(hrp, version, bin)
+    }
+
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/DerivationTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/DerivationTool.kt
@@ -59,6 +59,7 @@ interface DerivationTool {
      */
     suspend fun deriveUnifiedSpendingKey(
         transparentKey: ByteArray,
+        extendedSecretKey: ByteArray,
         seed: ByteArray,
         network: ZcashNetwork,
         account: Account


### PR DESCRIPTION
Brings functionality current with `Verus-mobile`, `librustzcash` and `react-native-verus`